### PR TITLE
Optimising image differencing kernel

### DIFF
--- a/config/imageDifference.py
+++ b/config/imageDifference.py
@@ -18,6 +18,14 @@ config.refObjLoader.defaultFilter='m'
 config.refObjLoader.filterMap={'L':'v'}
 
 config.doSelectSources= True
+config.doDetection = True
+config.doMeasurement = False
+config.doDipoleFitting = False
+config.doWriteSources = False
+config.doMerge = True
+config.doPreConvolve = True
+config.doDecorrelation = True
+
 config.kernelSourcesFromRef=True
 
 #config.subtract["al"].selectDetection.reEstimateBackground = True
@@ -26,9 +34,29 @@ config.kernelSourcesFromRef=True
 config.astrometer.matcher.maxMatchDistArcSec = 2.
 config.astrometer.wcsFitter.maxScatterArcsec = 10.0
 
+
 config.detection.minPixels = 5
 
-#config.doPreConvolve=True
+config.sourceSelector.fluxMin = 1000.0
+config.sourceSelector.fluxMax = 0
+
+config.sourceSelector.widthMin = 1.0
+config.sourceSelector.widthMax = 4.0
+config.sourceSelector.widthStdAllowed = 4.0
+config.sourceSelector.nSigmaClip = 3.0
+
+config.subtract['al'].kernel['AL'].spatialKernelOrder = 2
+
+# Number of Gaussians in alard-lupton basis
+config.subtract['al'].kernel['AL'].alardNGauss = 2
+
+# Polynomial order of spatial modification of Gaussians.  Must in number equal alardNGauss
+config.subtract['al'].kernel['AL'].alardDegGauss = [4,4]
+
+# Sigma in pixels of Gaussians (FWHM = 2.35 sigma).  Must in number equal alardNGauss
+config.subtract['al'].kernel['AL'].alardSigGauss = [1.0, 1.0]
+
+config.detection.minPixels = 10
 
 #config.subtract['zogy'].kernel.name = "AL"
 #config.subtract="zogy"


### PR DESCRIPTION
Adjusted the kernel fitting parameters. The kernel model is less flexible than the default, with the reduced flexibility seemingly reducing residuals in the difference image.