### PR TITLE
Using writeRecipes.yaml to control the level of compression

### DIFF
--- a/policy/writeRecipes.yaml
+++ b/policy/writeRecipes.yaml
@@ -1,0 +1,9 @@
+FitsStorage:
+  default:
+    image:
+      compression:
+        quantizeLevel: 16
+    variance:
+      compression:
+        quantizeLevel: 16
+      


### PR DESCRIPTION
quantizeLevel controls the level of lossy compression for float images. I have set this to 16 to match the level used in gotophoto.