### PR TITLE
Edit ingest

### DIFF
--- a/config/ingest.py
+++ b/config/ingest.py
@@ -12,7 +12,9 @@ config.parse.translation = {'dataType':'IMGTYPE',
 
 config.parse.translators = {'dateObs':'translateDate',
                             'taiObs':'translateDate',
-                            'visit':'translateVisit'}
+                            'visit':'translateVisit',
+                            'mjd':'translateJd',
+                            'survey':'translateSurvey'}
 
 config.register.visit = ['visit', 'run', 'ccd', 'filter', 'dateObs','taiObs']
 
@@ -26,5 +28,7 @@ config.register.columns = {'run':'int',
                            'expTime':'double',
                            'dateObs':'text',
                            'taiObs':'text',
-                           'field':'text'}
+                           'mjd':'double',
+                           'field':'text',
+                           'survey':'text'}
 

--- a/python/lsst/obs/goto/ingest.py
+++ b/python/lsst/obs/goto/ingest.py
@@ -52,11 +52,11 @@ class GotoParseTask(ParseTask):
 
     def translateJd(self, md):
         jd = md.get('JD')
-        return float(JD-2400000.5)
+        return float(jd-2400000.5)
 
     def translateSurvey(self, md):
         tileName = md.get('TILENAME')
-        event = md.getEvent('EVENT')
+        event = md.get('EVENT')
         if (tileName != 'NA') and (event == 'NA'):
             return 'T'
         else:

--- a/python/lsst/obs/goto/ingest.py
+++ b/python/lsst/obs/goto/ingest.py
@@ -50,3 +50,14 @@ class GotoParseTask(ParseTask):
         ccd = md.get("INSTRUME")
         return int(ccd.strip('UT'))
 
+    def translateJd(self, md):
+        jd = md.get('JD')
+        return float(JD-2400000.5)
+
+    def translateSurvey(self, md):
+        tileName = md.get('TILENAME')
+        event = md.getEvent('EVENT')
+        if (tileName != 'NA') and (event == 'NA'):
+            return 'T'
+        else:
+            return 'F'


### PR DESCRIPTION
Add 'survey' and 'mjd' columns in registry. New registries can be generated and replace old registries without ruining the book-keeping of processed frames.